### PR TITLE
Create a temporary build directory if none specified in "install component" script

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,12 +25,10 @@ the `examples` subdirectory.
 
 Builds and installs a specific component of GPG.
 
-Three options are mandatory:
+Two options are mandatory:
 
 * `--component`, which specifies a component name
 * `--version`, which specifies component version (can be `latest`)
-* `--build-dir`, which specifies a directory that the source code should be
-  fetched into, and where compilation should happen.
 
 For example, following snippet will build and install the most recent release
 of Pinentry:
@@ -39,8 +37,7 @@ of Pinentry:
 ----
 ./install_gpg_component.sh \
   --component pinentry \
-  --version latest \
-  --build-dir ./build-gpg
+  --version latest
 ----
 
 Furthermore, script is capable of fetching source from Git repository (instead
@@ -53,8 +50,7 @@ example, following will build the current master of Pinentry component:
 ./install_gpg_component.sh \
   --component pinentry \
   --version master \
-  --git \
-  --build-dir ~/build-gpg
+  --git
 ----
 
 Run script with `--help` option in order to display a more detailed
@@ -80,7 +76,6 @@ defined as follows:
 Prefer `latest` over `2.2`.
 
 Any other parameters supplied will be passed to `install_gpg_component.sh`.
-In particular, `--build-dir` is required.
 
 For example, following snippet will install the freshest GPG, and its components
 without documentation:

--- a/examples/components_individually.sh
+++ b/examples/components_individually.sh
@@ -16,28 +16,21 @@ set -v # Print executed lines
 #    SETUP    #
 ###############
 
-# The install_gpg_component.sh script requires passing a --build-dir option.
 BUILD_DIR="${TRAVIS_BUILD_DIR}/b"
 
 # Install specific versions of some components.  Disable documentation for
 # libgpg-error, and enable it (default) for other components.
 # In order to satisfy dependencies, components should be installed
 # in a specific order.
-./install_gpg_component.sh --component libgpg-error --version latest \
-  --build-dir "${BUILD_DIR}" --sudo \
+./install_gpg_component.sh --component libgpg-error --version latest --sudo \
   --configure-opts "--disable-doc"
-./install_gpg_component.sh --component libgcrypt --version latest \
-  --build-dir "${BUILD_DIR}" --sudo
-./install_gpg_component.sh --component libassuan --version latest \
-  --build-dir "${BUILD_DIR}" --sudo
-./install_gpg_component.sh --component libksba --version latest \
-  --build-dir "${BUILD_DIR}" --sudo
-./install_gpg_component.sh --component npth --version latest \
-  --build-dir "${BUILD_DIR}" --sudo
-./install_gpg_component.sh --component pinentry --version 1.1.0 \
-  --build-dir "${BUILD_DIR}" --sudo
-./install_gpg_component.sh --component gnupg --version 2.2.10 \
-  --build-dir "${BUILD_DIR}" --sudo \
+./install_gpg_component.sh --component libgcrypt --version latest --sudo \
+  --build-dir "${BUILD_DIR}"
+./install_gpg_component.sh --component libassuan --version latest --sudo
+./install_gpg_component.sh --component libksba --version latest --sudo
+./install_gpg_component.sh --component npth --version latest --sudo
+./install_gpg_component.sh --component pinentry --version 1.1.0 --sudo
+./install_gpg_component.sh --component gnupg --version 2.2.10  --sudo \
   --configure-opts "--enable-gpg-sha256 --disable-gpg-sha512 --enable-doc"
 
 ###############
@@ -60,3 +53,11 @@ gpg --version | grep -i "SHA256"
 # Assert disabled docs for libgpg-error, and enabled for other packages…
 [[   -f "/usr/local/share/man/man1/gpg.1" ]]
 [[ ! -f "/usr/local/share/man/man1/gpg-error-config.1" ]]
+
+# Assert that building the libgcrypt component has happened in a $BUILD_DIR,
+# and no other component was built there…
+pushd ${BUILD_DIR}
+ls -d libgcrypt-*
+[[ ! $(ls . | grep -v "libgcrypt-") ]]
+[[ -f "$(ls | grep "libgcrypt-")/Makefile" ]]
+popd

--- a/install_gpg_all.sh
+++ b/install_gpg_all.sh
@@ -21,7 +21,7 @@ errx() {
 }
 
 usage() {
-	echo "usage: $__progname [-t <TEMP_BUILD_DIR>] [-i <GPG_VERSION>] [-d]"
+	echo "usage: $__progname [-i <GPG_VERSION>] [-d]"
 	echo ""
 	echo "  Options:"
 	echo "  -d for dry run, not building GPG components."
@@ -32,7 +32,6 @@ usage() {
 	echo "  -h to display this message"
 	echo ""
 	echo "  Arguments can also be set via environment variables: "
-	echo "  - TEMP_BUILD_DIR"
 	echo "  - GPG_VERSION"
 	exit 1
 }
@@ -49,11 +48,8 @@ detect_platform() {
 
 main() {
 
-	while getopts ":t:idh" o; do
+	while getopts ":idh" o; do
 		case "${o}" in
-		t)
-			readonly local TEMP_BUILD_DIR=1
-			;;
 		i)
 			readonly local GPG_VERSION=${OPTARG}
 			;;
@@ -73,9 +69,6 @@ main() {
 		GPG_VERSION="latest"
 	fi
 
-	[[ ! "$TEMP_BUILD_DIR" ]] && \
-		TEMP_BUILD_DIR="$(mktemp -d)"
-
 	DISTRO="$(detect_platform)"
 
 	case $DISTRO in
@@ -87,40 +80,40 @@ main() {
 
 	case "$GPG_VERSION" in
 		"2.2")
-			./install_gpg_component.sh --component libgpg-error --version 1.31 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libgcrypt --version 1.8.2 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libassuan --version 2.5.1 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libksba --version 1.3.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component npth --version 1.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component pinentry --version 1.1.0 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component gnupg --version 2.2.7 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgpg-error --version 1.31 "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version 1.8.2 "${@:2}"
+			./install_gpg_component.sh --component libassuan --version 2.5.1 "${@:2}"
+			./install_gpg_component.sh --component libksba --version 1.3.5 "${@:2}"
+			./install_gpg_component.sh --component npth --version 1.5 "${@:2}"
+			./install_gpg_component.sh --component pinentry --version 1.1.0 "${@:2}"
+			./install_gpg_component.sh --component gnupg --version 2.2.7 "${@:2}"
 			;;
 		"2.1")
-			./install_gpg_component.sh --component libgpg-error --version 1.27 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libgcrypt --version 1.7.6 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libassuan --version 2.4.3 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libksba --version 1.3.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component npth --version 1.2 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component pinentry --version 0.9.5 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component gnupg --version 2.1.20 --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgpg-error --version 1.27 "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version 1.7.6 "${@:2}"
+			./install_gpg_component.sh --component libassuan --version 2.4.3 "${@:2}"
+			./install_gpg_component.sh --component libksba --version 1.3.5 "${@:2}"
+			./install_gpg_component.sh --component npth --version 1.2 "${@:2}"
+			./install_gpg_component.sh --component pinentry --version 0.9.5 "${@:2}"
+			./install_gpg_component.sh --component gnupg --version 2.1.20 "${@:2}"
 			;;
 		"latest")
-			./install_gpg_component.sh --component libgpg-error --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libgcrypt --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libassuan --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libksba --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component npth --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component pinentry --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component gnupg --version latest --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgpg-error --version latest "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version latest "${@:2}"
+			./install_gpg_component.sh --component libassuan --version latest "${@:2}"
+			./install_gpg_component.sh --component libksba --version latest "${@:2}"
+			./install_gpg_component.sh --component npth --version latest "${@:2}"
+			./install_gpg_component.sh --component pinentry --version latest "${@:2}"
+			./install_gpg_component.sh --component gnupg --version latest "${@:2}"
 			;;
 		"master")
-			./install_gpg_component.sh --component libgpg-error --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libgcrypt --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libassuan --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component libksba --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component npth --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component pinentry --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
-			./install_gpg_component.sh --component gnupg --version master --git --build-dir "$TEMP_BUILD_DIR" "${@:2}"
+			./install_gpg_component.sh --component libgpg-error --version master --git "${@:2}"
+			./install_gpg_component.sh --component libgcrypt --version master --git "${@:2}"
+			./install_gpg_component.sh --component libassuan --version master --git "${@:2}"
+			./install_gpg_component.sh --component libksba --version master --git "${@:2}"
+			./install_gpg_component.sh --component npth --version master --git "${@:2}"
+			./install_gpg_component.sh --component pinentry --version master --git "${@:2}"
+			./install_gpg_component.sh --component gnupg --version master --git "${@:2}"
 			;;
 	esac
 


### PR DESCRIPTION
Till now, `install_gpg_component.sh` requires specifying a build directory in which the build should happen. On the other hand, `install_gpg_all.sh` is able to create a temporary directory for that purpose if none specified.

This change moves this feature from `install_gpg_all.sh` to `install_gpg_component.sh`. Also, `-t` option is removed from `install_gpg_all.sh` as it now fully duplicates functionality of `--build-dir` option in `install_gpg_component.sh` script.