### PR TITLE
Improve in-script help

### DIFF
--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -28,7 +28,7 @@ EXAMPLES
 	install_gpg_component.rb --component-name libgpg-error --component-git-ref master
 
 	# Passing options to ./configure script
-	install_gpg_component.rb --component-name libgpg-error --component-version latest --configure-opts "--disable-doc --exec-prefix=/my/bin"
+	install_gpg_component.rb --component-name libgpg-error --component-version latest --configure-opts "--disable-doc"
 
 OPTIONS
 


### PR DESCRIPTION
Actually, `/my/bin` is a very bad example for `--exec-prefix`, which is a prefix for all platform-specific files, not only executables.