### PR TITLE
Test "no sudo" example in a sudoless environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: xenial
 
 install:
 
+before_script:
+  # Disable sudo for travis user in no_sudo build
+  - if [[ "${SCRIPT}" = "no_sudo" ]]; then sudo rm /etc/sudoers.d/travis; fi
+
 script:
   - examples/${SCRIPT}.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ env:
   matrix:
     - SCRIPT="all_latest"
     - SCRIPT="all_head"
-    - SCRIPT="all_2.2"
     - SCRIPT="all_2.1"
+    - SCRIPT="all_2.2"
     - SCRIPT="build_dir"
-    - SCRIPT="configure_options"
-    - SCRIPT="install_prefix"
-    - SCRIPT="no_sudo"
     - SCRIPT="components_individually"
+    - SCRIPT="configure_options"
     - SCRIPT="folding_travis"
     - SCRIPT="gpgme"
+    - SCRIPT="install_prefix"
+    - SCRIPT="no_sudo"
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ before_script:
 script:
   - examples/${SCRIPT}.sh
 
-matrix:
-  include:
-    - env: SCRIPT="all_latest"
-    - env: SCRIPT="all_head"
-    - env: SCRIPT="all_2.2"
-    - env: SCRIPT="all_2.1"
-    - env: SCRIPT="build_dir"
-    - env: SCRIPT="configure_options"
-    - env: SCRIPT="install_prefix"
-    - env: SCRIPT="no_sudo"
-    - env: SCRIPT="components_individually"
-    - env: SCRIPT="folding_travis"
-    - env: SCRIPT="gpgme"
+env:
+  matrix:
+    - SCRIPT="all_latest"
+    - SCRIPT="all_head"
+    - SCRIPT="all_2.2"
+    - SCRIPT="all_2.1"
+    - SCRIPT="build_dir"
+    - SCRIPT="configure_options"
+    - SCRIPT="install_prefix"
+    - SCRIPT="no_sudo"
+    - SCRIPT="components_individually"
+    - SCRIPT="folding_travis"
+    - SCRIPT="gpgme"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 
 install:
 
@@ -9,24 +8,13 @@ script:
 matrix:
   include:
     - env: SCRIPT="all_latest"
-      sudo: required
     - env: SCRIPT="all_head"
-      sudo: required
     - env: SCRIPT="all_2.2"
-      sudo: required
     - env: SCRIPT="all_2.1"
-      sudo: required
     - env: SCRIPT="build_dir"
-      sudo: required
     - env: SCRIPT="configure_options"
-      sudo: required
     - env: SCRIPT="install_prefix"
-      sudo: required
     - env: SCRIPT="no_sudo"
-      sudo: false
     - env: SCRIPT="components_individually"
-      sudo: required
     - env: SCRIPT="folding_travis"
-      sudo: required
     - env: SCRIPT="gpgme"
-      sudo: required

--- a/examples/no_sudo.sh
+++ b/examples/no_sudo.sh
@@ -35,6 +35,11 @@ mkdir -p ${GPG_PREFIX}
 #    TESTS    #
 ###############
 
+# Assert that sudo is not available in current environment
+# (You may need to comment it out when running on your local machine)…
+sudo --non-interactive true || SUDO_UNAVAILABLE=1
+[[ ${SUDO_UNAVAILABLE} -eq 1 ]]
+
 # Assert path to executable…
 [[ $(which gpg) == "${GPG_PREFIX}/bin/gpg" ]]
 


### PR DESCRIPTION
- Get rid of old `sudo: false` and `sudo: required` options, which have been removed from Travis CI.
- Find an alternative way to disable `sudo` in certain builds.
- Simplify Travis build matrix, as it no longer requires `sudo: false` tweaks.

Fixes #33.