### PR TITLE
Add an option to verify signatured of GnuPG tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ env:
     - SCRIPT="gpgme"
     - SCRIPT="install_prefix"
     - SCRIPT="no_sudo"
-    
+    - SCRIPT="verify"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_script:
   # Disable sudo for travis user in no_sudo build
   - if [[ "${SCRIPT}" = "no_sudo" ]]; then sudo rm /etc/sudoers.d/travis; fi
 
+  # Import GnuPG keys for "verify.sh" example.
+  - gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 249B39D24F25E3B6 2071B08A33BD3F06 04376F3EE0856959 BCEF7E294B092E28
+
 script:
   - examples/${SCRIPT}.sh
 

--- a/README.adoc
+++ b/README.adoc
@@ -138,6 +138,54 @@ The `./configure` script assumes that all the dependencies are installed in
 You may see a bunch of warnings as some of these options are relevant only to
 few components, but that won't break your build.
 
+=== Verifying authenticity of tarballs
+
+GnuPG team provides PGP signatures of released tarballs, which can be used
+to verify authenticity of these tarballs.  Note that using this feature requires
+that another installation of GnuPG is available in advance.
+
+In order to do so, firstly public keys of GnuPG team must be imported.
+The easiest way is to fetch them from some keyserver, for example from
+keyserver.ubuntu.com:
+
+[source,bash]
+----
+gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv-keys AAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB CCCCCCCCCCCCCCCCCC
+----
+
+You should obtain key IDs from https://www.gnupg.org/signature_key.html[GnuPG
+home page] rather than trust me, therefore above snippet contains only
+placeholders.  Key ID is the last sixteen hexadecimal digits of its fingerprint.
+
+Alternatively, you may write a whole ASCII-armored public key block, which is
+printed near the bottom of the aforementioned page, into some file, and then
+import it.  Given that you have saved key block to a file `GPG_KEYS.gpg`,
+following imports it:
+
+[source,bash]
+----
+gpg --import GPG_KEYS.gpg
+----
+
+Keys are now imported but not trusted yet.  It is enough for signature
+verification, though warnings will be printed.  In order to enable verfication,
+use `--verify` option, for example:
+
+[source,bash]
+----
+./install_gpg_all.sh \
+  --suite-version latest \
+  --verify
+----
+
+TIP: If you want to learn how to exchange and trust keys, head to
+https://www.gnupg.org/gph/en/manual/x56.html[GNU Privacy Handbook].
+
+TIP: For more information about checking integrity of GnuPG release tarballs,
+head to https://www.gnupg.org/download/integrity_check.html[GnuPG home page].
+
 === Using with Travis CI
 
 This scripts have been designed to work in Travis CI.  Use following listing

--- a/examples/verify.sh
+++ b/examples/verify.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e # Early exit if any command returns non-zero status code
+set -v # Print executed lines
+
+# This example shows how to verify downloade GnuPG distribution prior installing
+# it.  Note that this feature requires that some version of GnuPG (possibly
+# an old one) is installed in advance.
+
+###############
+#    SETUP    #
+###############
+
+# Firstly, public keys which will be used for GnuPG distribution verification
+# must be imported.  For security reasons, you need to do it yourself.
+#
+# A public key block with current keys can be found on this page:
+# https://www.gnupg.org/signature_key.html
+#
+# Then, keys can be imported by executing something of:
+# $ gpg --import FILE_WITH_KEY_BLOCK
+#
+# For more about importing keys (and trusting them) in G
+
+# The --sudo option is typically needed when installing to standard locations.
+# Note that `sudo ./install_gpg_all …` is not the same—it would compile as
+# root (not recommended), and won't trigger post-install steps (including
+# ldconfig).
+./install_gpg_all.sh --suite-version 2.2 --sudo --verify 2>&1 | tee ./output
+
+###############
+#    TESTS    #
+###############
+
+# Assert path to executable…
+[[ $(which gpg) == "/usr/local/bin/gpg" ]]
+
+# Assert that executable actually works…
+gpg --version
+
+# Assert executable version…
+gpg --version | head -n 1 | cut -d" " -f 3 | grep -xE "2\.2\.[0-9]+"
+
+# Assert that verification has happened…
+grep -F "gpg: Good signature from" ./output | tee ./good_signatures
+[[ `wc -l < ./good_signatures` -gt 6 ]]

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -32,6 +32,8 @@ EXAMPLES
 
 OPTIONS
 
+	Basic options:
+
 	--component-name COMPONENT
 		Component to install.  This option is mandatory.
 
@@ -48,6 +50,16 @@ OPTIONS
 
 		Either --component-version or --component-git-ref is mandatory.
 
+	Build options:
+
+	--build-dir DIR
+		Directory in which the compilation will happen.  Content may be
+		overwritten during build.  Directory will be created if non-existent.
+		If not set, a temporary directory will be created.
+
+	--configure-opts OPTS
+		Options to be passed to "./configure" script.
+
 	--[no-]sudo
 		Whether to do 'sudo make install', or just 'make install', and whether
 		to update ldconfig configuration. Note that the ldconfig update is
@@ -55,13 +67,7 @@ OPTIONS
 		'--prefix' configure options changes. Consider 'LD_LIBRARY_PATH' in
 		these cases. By default it is off.
 
-	--configure-opts OPTS
-		Options to be passed to "./configure" script.
-
-	--build-dir DIR
-		Directory in which the compilation will happen.  Content may be
-		overwritten during build.  Directory will be created if non-existent.
-		If not set, a temporary directory will be created.
+	Output options:
 
 	--folding-style STYLE
 		If set, enables output folding.  STYLE defines the folding notation
@@ -73,6 +79,8 @@ OPTIONS
 		"travis"
 			Fold output for Travis CI builds.  See this example Travis job:
 			https://api.travis-ci.org/v3/job/15440998/log.txt
+
+	Help:
 
 	--help, -h
 		Displays this message
@@ -106,6 +114,12 @@ parse_cli_arguments()
 				shift
 				shift
 				;;
+			--component-git-ref)
+				_arg_version="$2"
+				_arg_git="on"
+				shift
+				shift
+				;;
 			--build-dir)
 				_arg_build_dir="$2"
 				shift
@@ -122,12 +136,6 @@ parse_cli_arguments()
 				;;
 			--no-sudo)
 				_arg_sudo="off"
-				shift
-				;;
-			--component-git-ref)
-				_arg_version="$2"
-				_arg_git="on"
-				shift
 				shift
 				;;
 			--folding-style)

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -67,6 +67,14 @@ OPTIONS
 		'--prefix' configure options changes. Consider 'LD_LIBRARY_PATH' in
 		these cases. By default it is off.
 
+	--[no-]verify
+		Whether to verify signatures of tarballs with GnuPG distribution or not.
+		By default it is off.
+
+		This option requires that gpg is already in $PATH at build time.
+
+		This option is incompatible with --component-git-ref.
+
 	Output options:
 
 	--folding-style STYLE
@@ -93,6 +101,7 @@ set_default_options()
 	_arg_build_dir=
 	_arg_configure_opts=
 	_arg_sudo="off"
+	_arg_verify="off"
 	_arg_git="off"
 	_arg_color="off"
 	_arg_folding_style="none"
@@ -138,6 +147,14 @@ parse_cli_arguments()
 				_arg_sudo="off"
 				shift
 				;;
+			--verify)
+				_arg_verify="on"
+				shift
+				;;
+			--no-verify)
+				_arg_verify="off"
+				shift
+				;;
 			--folding-style)
 				_arg_folding_style="$2"
 				shift
@@ -165,6 +182,16 @@ set_important_configure_options()
 	fi
 }
 
+ensure_options_compatibility()
+{
+	if [[ ${_arg_git} == "on" ]] && [[ ${_arg_verify} = "on" ]]; then
+		echo <<ECHO
+ERROR --verify option cannot be used together with --component-git-ref.
+ECHO
+		exit 600
+	fi
+}
+
 display_config()
 {
 	cat <<CONFIG
@@ -172,6 +199,7 @@ component: "${_arg_component}"
 version: "${_arg_version}"
 git: "${_arg_git}"
 sudo: "${_arg_sudo}"
+verify: "${_arg_verify}"
 build_dir: "${_arg_build_dir:-<temporary directory>}"
 configure_options: "${_arg_configure_opts}"
 
@@ -223,7 +251,12 @@ fetch_release()
 {
 	local _tarball_file_name="${_arg_component}-${_arg_version}.tar.bz2"
 	local _tarball_url="https://gnupg.org/ftp/gcrypt/${_arg_component}/${_tarball_file_name}"
+	local _signature_url="${_tarball_url}.sig"
 	curl ${_tarball_url} --remote-name --retry 5
+	if [[ "${_arg_verify}" = "on" ]]; then
+		curl ${_signature_url} --remote-name --retry 5
+		verify_tarball_signature ${_tarball_file_name}
+	fi
 	tar -xjf ${_tarball_file_name}
 	rm ${_tarball_file_name}
 	set_component_build_dir "${_arg_component}-${_arg_version}"
@@ -246,6 +279,13 @@ fetch_from_git()
 		git pull # in case of outdated local branch
 		popd
 	fi
+}
+
+verify_tarball_signature()
+{
+	local _tarball_file_name=$1
+	local _signature_file_name="${_tarball_file_name}.sig"
+	gpg --verify "${_signature_file_name}" "${_tarball_file_name}"
 }
 
 build_and_install()
@@ -330,6 +370,7 @@ set -e # Early exit if any command returns non-zero status code
 
 set_default_options
 parse_cli_arguments "$@"
+ensure_options_compatibility
 set_important_configure_options
 
 fold_start "component.${_arg_component}"


### PR DESCRIPTION
Add a `--verify` option which verifies PGP signatures of tarballs containing GnuPG source code. Fixes #30.