### PR TITLE
Avoid too much spacing in the output

### DIFF
--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -316,6 +316,10 @@ set_component_build_dir()
 	_component_build_dir=$1
 }
 
+######################
+#    PRETTY OUTPUT   #
+######################
+
 header()
 {
 	echo ""
@@ -324,10 +328,6 @@ header()
 	echo ""
 	echo ""
 }
-
-######################
-#    PRETTY OUTPUT   #
-######################
 
 fold_start()
 {

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -322,11 +322,19 @@ set_component_build_dir()
 
 header()
 {
-	echo ""
-	echo ""
-	echo "=== $1 ==="
-	echo ""
-	echo ""
+	case "${_arg_folding_style}" in
+		travis)
+			echo "=== $1 ==="
+			echo ""
+			;;
+		*)
+			echo ""
+			echo ""
+			echo "=== $1 ==="
+			echo ""
+			echo ""
+			;;
+	esac
 }
 
 fold_start()


### PR DESCRIPTION
When folding is enabled, do not print blank lines before component header as it makes output less readable rather than the opposite (header is invisible when folded).  Also, print less blank lines after the header.