### PR TITLE
Don't install additional software outside Travis

### DIFF
--- a/examples/all_head.sh
+++ b/examples/all_head.sh
@@ -11,8 +11,10 @@ set -v # Print executed lines
 ###############
 
 # When building from Git, some other packages are required to be installed.
-sudo apt-get update
-sudo apt-get install -y texinfo
+if [[ ( "${TRAVIS}" = "true" ) && ( "${TRAVIS_OS_NAME}" = "linux" ) ]]; then
+	sudo apt-get update
+	sudo apt-get install -y texinfo
+fi
 
 # The --sudo option is typically needed when installing to standard locations.
 # Note that `sudo ./install_gpg_all …` is not the same—it would compile as


### PR DESCRIPTION
Some examples require additional software when they are run in Travis CI. Add some flow control to prevent this software from being installed when not running in Travis CI.