### PR TITLE
ambiguity in SWDB component retrieval

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,12 +133,14 @@ follows:
   https://gist.github.com/mattrude/3883a3801613b048d45b
 * `2.2` means GnuPG 2.1, and other component as in this Gist:
   https://gist.github.com/vt0r/a2f8c0bcb1400131ff51
+* Currently no all in one support for explicit versioning with 
+  `2.3`, `2.4`, etc. arguments yet. Use `latest` instead.
 * `latest` means the latest version of GnuPG and all its components.  They are
   obtained from https://versions.gnupg.org/swdb.lst, which is maintained by
   GnuPG developers, and which is used by GnuPG's stock software updater.
 * `master` means whatever is currently on `master` branch in Git.
 
-TIP: Prefer `latest` over `2.2`.
+TIP: Prefer `latest` over explicit versioning.
 
 Any other arguments are passed to `install_gpg_component.sh`, which is invoked
 from `install_gpg_all.sh` for every component once.  For example, following

--- a/install_gpg_all.sh
+++ b/install_gpg_all.sh
@@ -23,13 +23,13 @@ DESCRIPTION
 EXAMPLES
 
 	# Installing latest version of all GnuPG software
-	install_gpg_component.sh --suite-version latest
+	install_gpg_all.sh --suite-version latest
 
 	# Installing GnuPG 2.1
-	install_gpg_component.sh --suite-version 2.1
+	install_gpg_all.sh --suite-version 2.1
 
 	# Passing options to install_gpg_component.sh scripts
-	install_gpg_component.sh --suite-version latest --sudo
+	install_gpg_all.sh --suite-version latest --sudo
 
 OPTIONS
 

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -11,7 +11,7 @@ print_help ()
 	cat <<HELP
 USAGE
 
-	install_gpg_component.rb <options>
+	install_gpg_component.sh <options>
 
 DESCRIPTION
 
@@ -20,16 +20,16 @@ DESCRIPTION
 EXAMPLES
 
 	# Installing latest version of libgpg-error
-	install_gpg_component.rb --component-name libgpg-error --component-version latest
+	install_gpg_component.sh --component-name libgpg-error --component-version latest
 
 	# Installing latest version of libgpg-error with sudo
-	install_gpg_component.rb --component-name libgpg-error --component-version latest --sudo
+	install_gpg_component.sh --component-name libgpg-error --component-version latest --sudo
 
 	# Installing latest git revision of libgpg-error
-	install_gpg_component.rb --component-name libgpg-error --component-git-ref master
+	install_gpg_component.sh --component-name libgpg-error --component-git-ref master
 
 	# Passing options to ./configure script
-	install_gpg_component.rb --component-name libgpg-error --component-version latest --configure-opts "--disable-doc"
+	install_gpg_component.sh --component-name libgpg-error --component-version latest --configure-opts "--disable-doc"
 
 OPTIONS
 

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -289,6 +289,7 @@ determine_latest_version_by_swdb()
 	_arg_version=$(curl -s "https://versions.gnupg.org/swdb.lst" |
 		grep "_ver" |
 		grep -v "w32" |
+		grep -v "gnupgdesk" |
 		sort --reverse |
 		grep "${_component_underscored}" |
 		head -n 1 |


### PR DESCRIPTION
Calling function `determine_latest_version_by_swdb()` with argument 'gnupg' falsely decides to install 'gnupgdesk'. Fix ambiguity in SWDB component retrieval by filtering out 'gnupgdesk'.